### PR TITLE
Align with https://github.com/w3c/licenses

### DIFF
--- a/templates/CG-contributing.md
+++ b/templates/CG-contributing.md
@@ -1,11 +1,11 @@
 # {{name}}
 
-This repository is being used for work in the {{name}}, governed by the [W3C Community License 
-Agreement (CLA)](http://www.w3.org/community/about/agreements/cla/). To contribute, you must join 
-the CG. 
+This repository is being used for work in the W3C {{name}}, governed by the [W3C Community License
+Agreement (CLA)](http://www.w3.org/community/about/agreements/cla/). To make substantive contributions,
+you must join the CG.
 
-If you are not the sole contributor to a contribution (pull request), please identify all 
-contributors in the pull request's body or in subsequent comments.
+If you are not the sole contributor to a contribution (pull request), please identify all
+contributors in the pull request comment.
 
 To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
 
@@ -19,5 +19,5 @@ If you added a contributor by mistake, you can remove them in a comment with:
 -@github_username
 ```
 
-If you are making a pull request on behalf of someone else but you had no part in designing the 
+If you are making a pull request on behalf of someone else but you had no part in designing the
 feature, you can remove yourself with the above syntax.

--- a/templates/CG-license.md
+++ b/templates/CG-license.md
@@ -1,5 +1,10 @@
-All Reports in this Repository are licensed by Contributors under the 
-[W3C Software and Document
-License](http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document). Contributions to
-Specifications are made under the [W3C CLA](https://www.w3.org/community/about/agreements/cla/).
+All Reports in this Repository are licensed by Contributors
+under the
+[W3C Software and Document License](http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).
+
+Contributions to Specifications are made under the
+[W3C CLA](https://www.w3.org/community/about/agreements/cla/).
+
+Contributions to Test Suites are made under the
+[W3C 3-clause BSD License](https://www.w3.org/Consortium/Legal/2008/03-bsd-license.html)
 

--- a/templates/WG-contributing.md
+++ b/templates/WG-contributing.md
@@ -1,25 +1,24 @@
 # {{name}}
 
-Contributions to this repository are intended to become part of Recommendation-track documents 
-governed by the [W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
-[Document License](http://www.w3.org/Consortium/Legal/copyright-documents). To contribute, you must 
-either participate in the relevant W3C Working Group or make a non-member patent licensing
- commitment.
+Contributions to this repository are intended to become part of Recommendation-track documents governed by the
+[W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
+[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software). To make substantive contributions to specifications, you must either participate
+in the relevant W3C Working Group or make a non-member patent licensing commitment.
 
-If you are not the sole contributor to a contribution (pull request), please identify all 
-contributors in the pull request's body or in subsequent comments.
+If you are not the sole contributor to a contribution (pull request), please identify all
+contributors in the pull request comment.
 
- To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
+To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
 
- ```
- +@github_username
- ```
+```
++@github_username
+```
 
- If you added a contributor by mistake, you can remove them in a comment with:
+If you added a contributor by mistake, you can remove them in a comment with:
 
- ```
- -@github_username
- ```
+```
+-@github_username
+```
 
- If you are making a pull request on behalf of someone else but you had no part in designing the 
- feature, you can remove yourself with the above syntax.
+If you are making a pull request on behalf of someone else but you had no part in designing the
+feature, you can remove yourself with the above syntax.

--- a/templates/WG-license.md
+++ b/templates/WG-license.md
@@ -1,2 +1,3 @@
-All documents in this Repository are licensed by contributors under the [W3C Document
-License](http://www.w3.org/Consortium/Legal/copyright-documents).
+All documents in this Repository are licensed by contributors
+under the
+[W3C Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software).


### PR DESCRIPTION
 and switch the default to the Software and Document license for WGs
