### PR TITLE
Turn off build notifications by e-mail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ node_js:
 services:
   - couchdb
 notifications:
-  email: false
+  email:
+    - dom@w3.org
 before_script:
   node store.js "./test/config-test.json"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - "8"
 services:
   - couchdb
+notifications:
+  email: false
 before_script:
   node store.js "./test/config-test.json"
 script:


### PR DESCRIPTION
Travis is sending me mail when build statuses change after my commits/PRs. I don't know about others, but I look at build statuses on PRs directly, and use web notifications instead. I don't like the extra noise of mail.

This disables [mail notifications](https://docs.travis-ci.com/user/notifications#Configuring-email-notifications) altogether. If other contributors like them, I can instead list their individual addresses on the Travis config file (and not include mine).