### PR TITLE
Fix nodemailer in production

### DIFF
--- a/server.js
+++ b/server.js
@@ -820,21 +820,7 @@ module.exports.run = run;
 module.exports.app = app;
 
 if (require.main === module) {
-    console.debug('--- started --- ' + new Date() + ' ---');
     // FIXME abstract into configuration the mailer parameters
     var transporter = nodemailer.createTransport({sendmail: true, path: '/usr/sbin/sendmail', tls: {rejectUnauthorized: false}});
-    console.dir(transporter);
-    const message = {
-	from: 'antonio@w3.org',
-	to: 'antonio@w3.org',
-	subject: '[Test ' + new Date() + ']',
-	text: '[Test ' + new Date() + ']',
-	replyTo: 'antonio@w3.org'
-    };
-    transporter.sendMail(message, (error, info) => {
-	if (error)
-	    console.dir(error);
-	console.dir(info);
-    });
     run(require("./config.json"), transporter);
 }

--- a/server.js
+++ b/server.js
@@ -820,7 +820,21 @@ module.exports.run = run;
 module.exports.app = app;
 
 if (require.main === module) {
+    console.debug('--- started --- ' + new Date() + ' ---');
     // FIXME abstract into configuration the mailer parameters
-    var transporter = nodemailer.createTransport({sendmail: true,  tls: {rejectUnauthorized: false}});
+    var transporter = nodemailer.createTransport({sendmail: true, path: '/usr/sbin/sendmail', tls: {rejectUnauthorized: false}});
+    console.dir(transporter);
+    const message = {
+	from: 'antonio@w3.org',
+	to: 'antonio@w3.org',
+	subject: '[Test ' + new Date() + ']',
+	text: '[Test ' + new Date() + ']',
+	replyTo: 'antonio@w3.org'
+    };
+    transporter.sendMail(message, (error, info) => {
+	if (error)
+	    console.dir(error);
+	console.dir(info);
+    });
     run(require("./config.json"), transporter);
 }


### PR DESCRIPTION
Ready to be merged.

**After merging, get rid of ad-hoc changes to one file on the production server, and instead check out `master` there again.**

---

This is what I have running in production right now.

Upon (re)starting the process with PM2, this test e-mail is sent successfully (I receive it). And debugging output looks right (both `transporter` and `info` objects).

I also tried manually running this minimal program on the same box (as user `node` and with `nodemailer` `5.0.0`):

```js
const nodemailer = require('nodemailer');
const transporter = nodemailer.createTransport({
  sendmail: true,
  path: '/usr/sbin/sendmail',
  tls: {rejectUnauthorized: false}
});
const message = {
  from: 'antonio@w3.org',
  to: 'antonio@w3.org',
  subject: '[Test ' + new Date() + ']',
  text: '[Test ' + new Date() + ']',
  replyTo: 'antonio@w3.org'
};
console.dir(transporter);
transporter.sendMail(message, (error, info) => {
  if (error)
    console.dir(error);
  console.dir(info);
});
```

It works fine, too.

The only meaningful change in this branch is that I added `path: '/usr/sbin/sendmail'` to the config object passed to `nodemailer.createTransport()`. (I did that because I noticed `which sendmail` as user `node` failed on the box).

---

The bug might be fixed, though &mdash; I'm waiting for a new meaningful PR to be processed. [This recent one](https://labs.w3.org/repo-manager/pr/id/w3c/webrtc-identity/26) I used for testing, but it might have failed simply because the submitter doesn't have a public e-mail address on GH (?).

I say it *might* be solved because after this change (adding `path: '/usr/sbin/sendmail'`) the `ENOENT` error has disappeared from the logs (see the third and last occurrence):

```
$ grep -A1 -i attempting /var/log/nodejs/ash-nazg-2.log
info: Attempting to notify error on w3c/resource-timing
error:  Error: spawn sendmail ENOENT
--
info: Attempting to notify error on w3c/microdata
error:  Error: spawn sendmail ENOENT
--
info: Attempting to notify error on w3c/webrtc-identity
info: Looking for user msmpro
```

---

Sharing it here, while I wait for more tests, in case @deniak or @dontcallmedom can spot other reasons why this might fail&hellip;