### PR TITLE
Add support for ignoring PRs touching only non-substantive files

### DIFF
--- a/gh.js
+++ b/gh.js
@@ -233,7 +233,7 @@ GH.prototype = {
             }));
         });
     if (!cb) return ret;
-    ret.then(emails =>cb(null, emails), cb);
+    ret.then(emails => cb(null, emails), cb);
 }
 ,   status: function (data, cb) {
         this.octo

--- a/gh.js
+++ b/gh.js
@@ -220,7 +220,7 @@ GH.prototype = {
     }
 ,   getRepoContacts: function (repofullname, cb) {
     var self = this;
-    self.octo
+    const ret = self.octo
         .repos(repofullname.split('/')[0], repofullname.split('/')[1])
         .contents('w3c.json').fetch()
         .then(function(w3cinfodesc) {
@@ -231,11 +231,10 @@ GH.prototype = {
                         return u.email;
                     });
             }));
-        }).then(function(emails) {
-            cb(null, emails);
-        })
-        .catch(cb);
-    }
+        });
+    if (!cb) return ret;
+    ret.then(emails =>cb(null, emails), cb);
+}
 ,   status: function (data, cb) {
         this.octo
             .repos(data.owner, data.shortName)
@@ -245,8 +244,16 @@ GH.prototype = {
             .catch(cb)
         ;
     }
+,   getPrFiles: function(owner, name, prnum, cb) {
+        const ret = this.octo
+            .repos(owner, name)
+            .pulls(prnum)
+            .files.fetch();
+        if (!cb) return ret;
+        ret.then(files => cb(null, files), cb);
+    }
 ,   getUser:    function (username, cb) {
-        this.octo
+        const ret = this.octo
             .users(username)
             .fetch()
             .then(function (user) {
@@ -270,10 +277,10 @@ GH.prototype = {
                 };
                 if (user.email) u.emails.push({ value: user.email });
                 if (user.avatar_url) u.photos.push({ value: user.avatar_url });
-                cb(null, u);
-            })
-            .catch(cb)
-        ;
+                return u;
+            });
+        if (!cb) return ret;
+        return ret.then(u => cb(null, u), cb);
     }
 };
 

--- a/gh.js
+++ b/gh.js
@@ -219,21 +219,19 @@ GH.prototype = {
         ;
     }
 ,   getRepoContacts: function (repofullname, cb) {
-    var self = this;
-    const ret = self.octo
-        .repos(repofullname.split('/')[0], repofullname.split('/')[1])
-        .contents('w3c.json').fetch()
-        .then(function(w3cinfodesc) {
-            var w3cinfo = JSON.parse(new Buffer(w3cinfodesc.content, 'base64').toString('utf8'));
-            return Promise.all(w3cinfo.contacts.map(function(username) {
-                return self.octo.users(username).fetch()
-                    .then(function(u) {
-                        return u.email;
-                    });
-            }));
-        });
-    if (!cb) return ret;
-    ret.then(emails => cb(null, emails), cb);
+       var self = this;
+       const ret = self.octo
+           .repos(repofullname.split('/')[0], repofullname.split('/')[1])
+           .contents('w3c.json').fetch()
+           .then(function(w3cinfodesc) {
+               var w3cinfo = JSON.parse(new Buffer(w3cinfodesc.content, 'base64').toString('utf8'));
+               return Promise.all(w3cinfo.contacts.map(function(username) {
+                   return self.octo.users(username).fetch()
+                       .then(u => u.email);
+               }));
+           });
+       if (!cb) return ret;
+       ret.then(emails => cb(null, emails), cb);
 }
 ,   status: function (data, cb) {
         this.octo

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "body-parser": "1.17.2",
     "cradle": "0.7.1",
     "curry": "1.2.0",
+    "doasync": "^2.0.1",
     "es6-object-assign": "1.1.0",
     "es6-promise": "4.1.1",
     "expect.js": "0.3.1",

--- a/pr-check.js
+++ b/pr-check.js
@@ -71,7 +71,7 @@ async function setGhStatus(gh, status) {
 }
 
 async function checkPrScope(gh, pr) {
-  const ignoreFiles = ["package.json", "package-lock.json", ".travis.yml", "w3c.json", "CONTRIBUTING.md", "LICENSE.md", "CODE_OF_CONDUCT.md"];
+  const ignoreFiles = ["package.json", "package-lock.json", ".travis.yml", "w3c.json", "CONTRIBUTING.md", "LICENSE.md", "LICENSE.txt", "CODE_OF_CONDUCT.md"];
   const ignorePath = ".github/";
   let files;
   try {

--- a/pr-check.js
+++ b/pr-check.js
@@ -72,7 +72,7 @@ async function setGhStatus(gh, status) {
 
 async function checkPrScope(gh, pr) {
   const ignoreFiles = ["package.json", "package-lock.json", ".travis.yml", "w3c.json", "CONTRIBUTING.md", "LICENSE.md", "CODE_OF_CONDUCT.md"];
-  const ignorePath = "./github/";
+  const ignorePath = ".github/";
   let files;
   try {
     ({items: files} = await gh.getPrFiles(pr.owner, pr.shortName, pr.num));
@@ -258,4 +258,3 @@ function prChecker(config, argLog, argStore, GH, mailer) {
 }
 
 module.exports = prChecker;
-

--- a/pr-check.js
+++ b/pr-check.js
@@ -1,0 +1,261 @@
+const async = require("async")
+,   notification = require('./notification')
+,   w3ciprcheck = require('./w3c-ipr')
+,   doAsync = require('doasync') // rather than utils.promisy to get "free" support for object methods
+,   w3c = require("node-w3capi");
+
+let store, log;
+
+async function findW3CUserFromGithub(user) {
+  log.info("Looking for github user with id " + user.ghID + " in W3C API");
+  try {
+    // can't easily promisify w3c API :(
+    let w3cuser = await new Promise((res, rej) => w3c.user({type: 'github', id: user.ghID}).fetch((err, u) => { if (err) return rej(err); return res(u);}));
+    log.info(JSON.stringify(w3cuser, null, 2));
+    await doAsync(store).mergeOnUser(user.username, {
+      w3cid:  w3cuser.id,
+      w3capi: w3cuser._links.self.href.replace(/.*\//, "")
+    });
+  } catch (err) {
+    return user;
+  }
+  log.info("Found matching W3C user");
+  return doAsync(store).getUser(user.username);
+}
+
+async function findOrCreateUserFromGithub(username, gh) {
+  let user;
+  try {
+    user = await doAsync(store).getUser(username);
+  } catch (err) {
+    if (err.error !== "not_found") throw err;
+  }
+  if (!user) {
+    log.info("Getting GH id from github for " + username);
+    let ghuser = await gh.getUser(username);
+    // we store this for sake of efficiency
+    await doAsync(store).addUser(ghuser);
+    return findW3CUserFromGithub(ghuser);
+  } else {
+    // Let's check if the link has since been established
+    if (!user.w3capi) {
+      return findW3CUserFromGithub(user);
+    } else {
+      return user;
+    }
+  }
+}
+
+
+async function getStoredPR(fullname) {
+  log.info("Setting status for PR " + fullname);
+  let repo = await doAsync(store).getRepo(fullname);
+  if (!repo) throw ("Unknown repository: " + fullname);
+  let token = await doAsync(store).getToken(repo.owner);
+  if (!token) throw ("Token not found for: " + repo.owner);
+  return {repoGroups: repo.groups, token};
+}
+
+async function updateStoredPR(pr) {
+  log.info("Setting status for PR " + pr.fullName);
+  let updatedPr = await doAsync(store).updatePR(pr.fullName, pr.num, pr);
+  return updatedPr;
+}
+
+async function setGhStatus(gh, status) {
+  try {
+    await doAsync(gh).status(status);
+  } catch(err) {
+    log.error(err);
+  }
+}
+
+async function checkPrScope(gh, pr) {
+  const ignoreFiles = ["package.json", "package-lock.json", ".travis.yml", "w3c.json", "CONTRIBUTING.md", "LICENSE.md", "CODE_OF_CONDUCT.md"];
+  const ignorePath = "./github/";
+  let files;
+  try {
+    ({items: files} = await gh.getPrFiles(pr.owner, pr.shortName, pr.num));
+  } catch(err) {
+    log.error(err);
+    // if unsure, assumes it is IPR-relevant
+    return true;
+  }
+  return !(files.map(f => f.filename).every(p => ignoreFiles.includes(p) || p.startsWith(ignorePath)));
+}
+
+function prChecker(config, argLog, argStore, GH, mailer) {
+  log = argLog;
+  store = argStore;
+  return {
+    validate: async function prStatus (pr, delta, cb) {
+      const currentPrAcceptability = pr.acceptable;
+      const prString = pr.owner + "/" + pr.shortName + "/" + pr.num;
+      const statusData = {
+        owner:      pr.owner,
+        shortName:  pr.shortName,
+        sha:        pr.sha,
+        payload:    {
+          state:          "pending",
+          target_url:     config.url + "pr/id/" + prString,
+          description:    "PR is being assessed, results will come shortly.",
+          context:        "ipr"
+        }
+      };
+      let token, repoGroups, iprRelevant = true;
+      try {
+        ({token, repoGroups} = await getStoredPR(pr.fullName));
+      } catch (err) {
+        return cb(err);
+      }
+      const gh = new GH({ accessToken: token.token });
+      log.info("Setting pending status on " + prString);
+      await setGhStatus(gh, statusData);
+
+      iprRelevant = await checkPrScope(gh, pr, log);
+      if (!iprRelevant) {
+        statusData.payload.state = "success";
+        statusData.payload.description = "PR files identified as non-substantive.";
+        log.info("Setting status success for " + prString);
+        pr.acceptable = "yes";
+        await setGhStatus(gh, statusData);
+        try {
+          let updatedPR = await updateStoredPR(pr);
+          return cb(null, updatedPR);
+        } catch (err) {
+          return cb(err);
+        }
+      }
+
+      if (pr.markedAsNonSubstantiveBy) {
+        pr.acceptable = "yes";
+        statusData.payload.state = "success";
+        statusData.payload.description = "PR deemed acceptable as non-substantive by @" + pr.markedAsNonSubstantiveBy + ".";
+        log.info("Setting status success for " + prString);
+        await setGhStatus(gh, statusData);
+        try {
+          let updatedPR = await updateStoredPR(pr);
+          return cb(null, updatedPR);
+        } catch (err) {
+          return cb(err);
+        }
+      }
+
+      log.info("Looking up users for " + prString);
+      let contrib = {};
+      log.info("Finding deltas for " + prString);
+      pr.contributors.forEach(function (c) { contrib[c] = true; });
+      delta.add.forEach(function (c) { contrib[c] = true; });
+      delta.remove.forEach(function (c) { delete contrib[c]; });
+      pr.contributors = Object.keys(contrib);
+      pr.contribStatus = {};
+      pr.groups = repoGroups;
+      pr.affiliations = {};
+      let results = await Promise.all(
+        pr.contributors.map(async function(username) {
+          let user = await findOrCreateUserFromGithub(username, gh);
+          // TODO: check that this is appropriate
+          // and if so, replace by check of affiliation
+          // to staff
+          if (user.blanket) {
+            pr.affiliations[user.affiliation] = user.affiliationName;
+            pr.contribStatus[username] = "ok";
+            return "ok";
+          }
+          // if user not found in W3C API,
+          // report undetermined affiliation
+          // TODO: We will contact contributor to ask
+          // establishing the connection.
+          if (!user.w3capi) {
+            pr.contribStatus[username] = "undetermined affiliation";
+            return "undetermined affiliation";
+          }
+          let result = await w3ciprcheck(w3c, user.w3capi, user.displayName, repoGroups, store);
+          let ok = result.ok;
+          if (ok) {
+            pr.affiliations[result.affiliation.id] = result.affiliation.name;
+            pr.contribStatus[username] = "ok";
+            return "ok";
+          } else {
+            // we assume that all groups are of the same type
+            let group = await doAsync(store).getGroup(repoGroups[0]);
+            if (!group) throw "Unknown group: " + repoGroups[0];
+            if (group.groupType === 'WG') {
+              log.info("Looking up for non-participant licensing contribution");
+              if (pr.repoId) {
+                let nplc;
+                try {
+                  nplc = await new Promise((res, rej) => w3c.nplc({repoId: pr.repoId, pr: pr.num}).fetch((err, n) => { if (err) return rej(err); return res(n);}));
+                } catch (err) {
+                  // Non-participant licensing contribution doesn't exist yet
+                  pr.contribStatus[username] = "no commitment made";
+                  return "no commitment made";
+                }
+                const u = nplc.commitments.find(c => c.user["connected-accounts"].find(ca => ca.nickname === username));
+                const contribStatus = (u.commitment_date === undefined) ? "commitment pending" : "ok";
+                pr.contribStatus[username] = contribStatus;
+                return contribStatus;
+              } else {
+                pr.contribStatus[username] = "no commiment made - missing repository ID";
+                return "no commiment made - missing repository ID";
+              }
+            } else {
+              pr.contribStatus[username] = "not in group";
+              return "not in group";
+            }
+          }
+        }));
+      let good = results.every(st => st === "ok");
+      log.info("Got users for " + prString + " results good? " + good);
+      if (good) {
+        pr.acceptable = "yes";
+        pr.unknownUsers = [];
+        pr.outsideUsers = [];
+        statusData.payload.state = "success";
+        statusData.payload.description = "PR deemed acceptable.";
+        log.info("Setting status success for " + prString);
+        await setGhStatus(gh, statusData);
+        let updatedPR = await updateStoredPR(pr);
+        return cb(null, updatedPR);
+      }
+      pr.acceptable = "no";
+      pr.unknownUsers = [];
+      pr.outsideUsers = [];
+      pr.unaffiliatedUsers = [];
+      for (var u in pr.contribStatus) {
+        if (pr.contribStatus[u] === "unknown") pr.unknownUsers.push(u);
+        if (pr.contribStatus[u] === "undetermined affiliation") pr.unaffiliatedUsers.push(u);
+        if (pr.contribStatus[u] === "not in group") pr.outsideUsers.push(u);
+      }
+      var msg = "PR has contribution issues.";
+      const collateUserNames = users => users.map(u => "@" + u).join (", ");
+      if (pr.unknownUsers.length)
+        msg += " The following users were unknown: " + collateUserNames(pr.unknownUsers) +
+        ".";
+      if (pr.unaffiliatedUsers.length)
+        msg += " The following users' affiliation could not be determined: " + collateUserNames(pr.unaffiliatedUsers) + ".";
+      if (pr.outsideUsers.length)
+        msg += " The following users were not in the repository's groups: " + collateUserNames(pr.outsideUsers) + ".";
+      statusData.payload.state = "failure";
+      statusData.payload.description =  msg;
+      if (statusData.payload.description.length > 140) {
+        statusData.payload.description = statusData.payload.description.slice(0, 139) + '…';
+      }
+      log.info("Setting status failure for " + prString + ", " + msg);
+      await setGhStatus(gh, statusData);
+      let updatedPR = await updateStoredPR(pr);
+      // Only send email notifications
+      // if the status of the PR has just
+      // changed
+      if (currentPrAcceptability !== pr.acceptable) {
+        // FIXME: make it less context-dependent
+        await notification.notifyContacts(gh, pr, statusData, mailer, {from: config.notifyFrom, fallback: config.emailFallback || [], cc: config.emailCC || []}, store, log);
+        return cb(null, updatedPR);
+      }
+      return cb(null, updatedPR);
+    }
+  };
+}
+
+module.exports = prChecker;
+

--- a/server.js
+++ b/server.js
@@ -575,6 +575,8 @@ function run(configuration, configuredmailer) {
     ,   secret:             config.sessionSecret
     }));
 
+    prChecker = new PRChecker(config, log, store, GH, mailer);
+
     passport.use(
         new GitHubStrategy({
             clientID:       config.ghClientID
@@ -604,7 +606,6 @@ function run(configuration, configuredmailer) {
                 log.info("Login successful: " + profile.username);
                 done(null, profile);
             });
-            prChecker = new PRChecker(config, log, store, GH, mailer);
         }
     ));
 

--- a/test/server-spec.js
+++ b/test/server-spec.js
@@ -19,7 +19,7 @@ var mockTransport = require('nodemailer-mock-transport');
 var transport = mockTransport();
 var transporter = nodemailer.createTransport(transport);
 
-var ghScope = "user:email,public_repo,write:repo_hook,read:org";
+var ghScope = "user:email,public_repo,writse:repo_hook,read:org";
 
 // simplify debugging of missed nock requests
 nock.emitter.on('no match', function(req, options, requestBody) {
@@ -103,7 +103,8 @@ var testCGRepo = new RepoMock(789, "cgrepo","acme", ["README.md", "index.html"],
 var testPR = {
     repository: testExistingRepo.toGH(),
     number: 5,
-    action: "opened",
+  action: "opened",
+  files: [{filename: "foo.bar"}],
     pull_request: {
         head: {
             sha: "fedcbafedcbafedcbafedcbafedcbafedcbafedc"
@@ -119,6 +120,7 @@ var testCGPR = {
     repository: testCGRepo.toGH(),
     number: 6,
     action: "opened",
+    files: [{filename: "foo.bar"}],
     pull_request: {
         head: {
             sha: "fedcba1fedcba1fedcba1fedcba1fedcba1fedcb"
@@ -134,6 +136,7 @@ var testWGPR = {
     repository: testExistingRepo.toGH(),
     number: 7,
     action: "opened",
+    files: [{filename: "foo.bar"}],
     pull_request: {
         head: {
             sha: "fedcba2fedcba2fedcba2fedcba2fedcba2fedcb"
@@ -144,6 +147,22 @@ var testWGPR = {
         body: null
     }
 };
+
+var testIPRFreePR = {
+    repository: testExistingRepo.toGH(),
+    number: 8,
+  action: "opened",
+  files: [{filename: "package.json", filename: "w3c.json"}],
+    pull_request: {
+        head: {
+            sha: "fedcbafedcbafedcbafedcbafedcbafedcbafedca"
+        },
+        user: {
+            login: testUser3.username
+        }
+    }
+};
+
 
 var expectedFilesInCreatedRepo = ["LICENSE.md", "CONTRIBUTING.md", "README.md", "CODE_OF_CONDUCT.md", "index.html", "w3c.json"];
 var expectedFilesInImportedRepo = ["LICENSE.md", "CONTRIBUTING.md", "README.md", "CODE_OF_CONDUCT.md", "w3c.json"];
@@ -489,6 +508,7 @@ describe('Server manages requests in a set up repo', function () {
             cleanStore("deletePR")(testExistingRepo.full_name, 5),
             cleanStore("deletePR")(testCGRepo.full_name, 6),
             cleanStore("deletePR")(testExistingRepo.full_name, 7),
+            cleanStore("deletePR")(testExistingRepo.full_name, 8),
             cleanStore("deleteUser")(testUser2.username),
             cleanStore("deleteUser")(testUser3.username)
         ], emptyNock(done));
@@ -550,6 +570,9 @@ describe('Server manages requests in a set up repo', function () {
     it('reacts to pull requests notifications from GH users without a known W3C account', function testPullRequestNotif(done) {
         mockPRStatus(testPR, 'pending', /.*/);
         nock('https://api.github.com')
+            .get('/repos/' + testExistingRepo.full_name + '/pulls/' + testPR.number + '/files')
+        .reply(200, testPR.files);
+        nock('https://api.github.com')
             .get('/repos/' + testExistingRepo.full_name + '/contents/w3c.json')
             .reply(200, {content: new Buffer(JSON.stringify({contacts:[testUser.username, testUser2.username]})).toString('base64'), encoding: "base64"});
 
@@ -588,9 +611,26 @@ describe('Server manages requests in a set up repo', function () {
             });
     });
 
+    it('approves pull requests from unknown GH users that only touch IPR-free files', function testIPRFreePullRequestNotif(done) {
+        mockPRStatus(testIPRFreePR, 'pending', /.*/);
+        nock('https://api.github.com')
+            .get('/repos/' + testExistingRepo.full_name + '/pulls/' + testIPRFreePR.number + '/files')
+        .reply(200, testIPRFreePR.files);
+        mockPRStatus(testIPRFreePR, 'success', /.*/);
+
+        req.post('/' + config.hookPath)
+            .send(testIPRFreePR)
+            .set('X-Github-Event', 'pull_request')
+            .set('X-Hub-Signature', GH.signPayload("sha1", passwordGenerator(20), new Buffer(JSON.stringify(testIPRFreePR))))
+            .expect(200, done);
+    });
+
 
     it('allows admins to revalidate a PR without re-notifying of failures', function testRevalidateNoNotif(done) {
         mockPRStatus(testPR, 'pending', /.*/);
+        nock('https://api.github.com')
+            .get('/repos/' + testExistingRepo.full_name + '/pulls/' + testPR.number + '/files')
+        .reply(200, testPR.files);
         nock('https://api.w3.org')
             .get('/users/connected/github/' + testUser2.ghID)
             .reply(404);
@@ -657,6 +697,9 @@ describe('Server manages requests in a set up repo', function () {
 
     it('allows logged-in users to revalidate a PR', function testRevalidate(done) {
         mockPRStatus(testPR, 'pending', /.*/);
+        nock('https://api.github.com')
+            .get('/repos/' + testExistingRepo.full_name + '/pulls/' + testPR.number + '/files')
+        .reply(200, testPR.files);
         mockUserAffiliation(testUser2, [w3cGroup]);
 
         // we assume that testUser3 has in the meantime linked his Github account
@@ -676,6 +719,9 @@ describe('Server manages requests in a set up repo', function () {
         forcedPR.action = "synchronize";
         forcedPR.pull_request.head.sha = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
         mockPRStatus(forcedPR, 'pending', /.*/);
+        nock('https://api.github.com')
+        .get('/repos/' + testExistingRepo.full_name + '/pulls/' + forcedPR.number + '/files')
+        .reply(200, forcedPR.files);
         mockUserAffiliation(testUser2, [w3cGroup]);
         mockUserAffiliation(testUser3, [], {groupid: w3cGroup.id});
         mockPRStatus(forcedPR, 'success', /.*/);
@@ -689,6 +735,9 @@ describe('Server manages requests in a set up repo', function () {
 
     it('rejects pull requests notifications from representatives of organizations in a CG', function testCGPullRequestNotif(done) {
         mockPRStatus(testCGPR, 'pending', /.*/);
+        nock('https://api.github.com')
+            .get('/repos/' + testCGRepo.full_name + '/pulls/' + testCGPR.number + '/files')
+        .reply(200, testCGPR.files);
         mockUserAffiliation(testUser3, []);
         nock('https://api.github.com')
             .get('/repos/' + testCGRepo.full_name + '/contents/w3c.json')
@@ -715,6 +764,9 @@ describe('Server manages requests in a set up repo', function () {
 
     it('accepts pull requests notifications from representatives of organizations in a WG', function testWGPullRequestNotif(done) {
         mockPRStatus(testWGPR, 'pending', /.*/);
+        nock('https://api.github.com')
+            .get('/repos/' + testExistingRepo.full_name + '/pulls/' + testWGPR.number + '/files')
+        .reply(200, testWGPR.files);
         mockUserAffiliation(testUser3, [], {groupid: w3cGroup.id});
 
         mockPRStatus(testWGPR, 'success', /.*/);
@@ -728,6 +780,9 @@ describe('Server manages requests in a set up repo', function () {
 
     it('revalidate a PR with non-member licensing commitments', function testRevalidate(done) {
         mockPRStatus(testWGPR, 'pending', /.*/);
+        nock('https://api.github.com')
+            .get('/repos/' + testExistingRepo.full_name + '/pulls/' + testWGPR.number + '/files')
+        .reply(200, testWGPR.files);
         mockUserAffiliation(testUser3, []);
         nock('https://api.w3.org')
             .get('/groups/' + w3cGroup.id + '/participations')

--- a/test/server-spec.js
+++ b/test/server-spec.js
@@ -19,7 +19,7 @@ var mockTransport = require('nodemailer-mock-transport');
 var transport = mockTransport();
 var transporter = nodemailer.createTransport(transport);
 
-var ghScope = "user:email,public_repo,writse:repo_hook,read:org";
+var ghScope = "user:email,public_repo,write:repo_hook,read:org";
 
 // simplify debugging of missed nock requests
 nock.emitter.on('no match', function(req, options, requestBody) {

--- a/w3c-ipr.js
+++ b/w3c-ipr.js
@@ -1,66 +1,62 @@
-var async = require("async")
-;
-
 const fromUrlToId = url => url.replace(/.*\//, "");
 
-module.exports = function iprcheck(w3c, w3cprofileid, name, w3cgroupids, store, cb) {
-    async.map(
-        w3cgroupids
-        , function(g, groupcb) {
-            store.getGroup(g, function(err, group) {
-                if (err) return groupcb(err);
-                w3c.user(w3cprofileid)
-                    .participations()
-                    .fetch({embed: true},
-                           function(err, participations) {
-                               if (err) return groupcb(err);
-                               for (var i = 0 ; i < participations.length; i++) {
-                                   var p = participations[i];
-                                   var org = p._links.organization;
-                                   var affiliation = p.individual ? {id: w3cprofileid, name: name} : {id: fromUrlToId(org.href), name: org.title};
-                                   if (p._links.group.href === "https://api.w3.org/groups/" + g) {
-                                       return groupcb(null, {ok: true, affiliation: affiliation});
-                                   }
-                               }
-                               // If we reach here,
-                               // the user is not participating directly in the group
-                               // For non WGs, game over
-                               if (group.groupType != "WG") {
-                                   return groupcb(null, {ok: false});
-                               }
-                               // For WGs, we check if the user is affiliated
-                               // with an organization that is participating
-                               w3c.group(g)
-                                   .participations()
-                                   .fetch({embed: true}, function(err, participations) {
-                                       if (err) return groupcb(err);
-                                       var orgids = participations
-                                           .filter(p => !p.individual)
-                                           .map(p => fromUrlToId(p._links.organization.href));
-                                       w3c.user(w3cprofileid)
-                                           .affiliations()
-                                           .fetch(function(err, affiliations) {
-                                               if (err) return groupcb(err);
-                                               var affids = affiliations.map(a => a ? fromUrlToId(a.href) : undefined);
-                                               var intersection = orgids.filter(id =>  affids.includes(id));
-                                               if (intersection.length) {
-                                                   var affiliationId = intersection[0];
-                                                   var affiliationName = affiliations.find(a => a.href == "https://api.w3.org/affiliations/" + affiliationId).title;
-                                                   return groupcb(null, {ok: true, affiliation: {id: affiliationId, name: affiliationName}});
-                                               }
-                                               return groupcb(null, {ok: false});
-                                           });
-                                   });
+module.exports = async function iprcheck(w3c, w3cprofileid, name, w3cgroupids, store, cb) {
+  return Promise.all(
+    w3cgroupids.map(
+      g => new Promise((res, rej) => {
+        store.getGroup(g, function(err, group) {
+          if (err) return rej(err);
+          w3c.user(w3cprofileid)
+            .participations()
+            .fetch({embed: true},
+                   function(err, participations) {
+                     if (err) return rej(err);
+                     for (var i = 0 ; i < participations.length; i++) {
+                       var p = participations[i];
+                       var org = p._links.organization;
+                       var affiliation = p.individual ? {id: w3cprofileid, name: name} : {id: fromUrlToId(org.href), name: org.title};
+                       if (p._links.group.href === "https://api.w3.org/groups/" + g) {
+                         return res({ok: true, affiliation: affiliation});
+                       }
+                     }
+                     // If we reach here,
+                     // the user is not participating directly in the group
+                     // For non WGs, game over
+                     if (group.groupType != "WG") {
+                       return res({ok: false});
+                     }
+                     // For WGs, we check if the user is affiliated
+                     // with an organization that is participating
+                     w3c.group(g)
+                       .participations()
+                       .fetch({embed: true}, function(err, participations) {
+                         if (err) return rej(err);
+                         var orgids = participations
+                             .filter(p => !p.individual)
+                             .map(p => fromUrlToId(p._links.organization.href));
+                         w3c.user(w3cprofileid)
+                           .affiliations()
+                           .fetch(function(err, affiliations) {
+                             if (err) return rej(err);
+                             var affids = affiliations.map(a => a ? fromUrlToId(a.href) : undefined);
+                             var intersection = orgids.filter(id =>  affids.includes(id));
+                             if (intersection.length) {
+                               var affiliationId = intersection[0];
+                               var affiliationName = affiliations.find(a => a.href == "https://api.w3.org/affiliations/" + affiliationId).title;
+                               return res({ok: true, affiliation: {id: affiliationId, name: affiliationName}});
+                             }
+                             return res({ok: false});
                            });
-            });
-        }, function(err, results) {
-            if (err) return cb(err);
-            for(var i = 0 ; i < results.length; i ++) {
-                var res = results[i];
-                if (res.ok) {
-                    return cb(null, {affiliation: res.affiliation, ok: true});
-                }
-            }
-            return cb(null, {affiliation: null, ok: false});
-        });
+                       });
+                   });
+        })
+      })))
+    .then(results => {
+      for(let res of results) {
+        if (res.ok) {
+          return {affiliation: res.affiliation, ok: true};
+        }
+      }
+      return {affiliation: null, ok: false};
+    });
 };


### PR DESCRIPTION
See https://github.com/w3c/ash-nazg/issues/125#issuecomment-599390829

In the process, refactor in depth the spaghetti code used for PR validation:
* split in a separate module
* using await/async for readability (relying on doAsync to convert callback functions)

This means the code now uses a mix of callbacks and promises async code,
which isn't ideal; also, the GH module is partially able to send back promises -
a good first clean-up would be to make that code at least fully promise-able.

But in the spirit of incremental improvement, this is I think overall an improvement on the current code, making it easier to update the PR validation steps.