### PR TITLE
Fix bug where ash-nazg doesn't report status on pull requests

### DIFF
--- a/gh.js
+++ b/gh.js
@@ -233,7 +233,7 @@ GH.prototype = {
     }
 ,   isAdmin:    function (username, orgOrUser, cb) {
         if (username === orgOrUser) {
-           return true;
+           return cb(null, true);
         }
         const ret = this.octo.request("GET /orgs/:orgOrUser/memberships/:username", {username, orgOrUser})
               .then(function ({data: role}) {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "watchify": "3.9.0"
   },
   "dependencies": {
+    "@octokit/core": "^3.1.0",
+    "@octokit/plugin-paginate-rest": "^2.2.3",
     "async": "2.5.0",
     "bl": "1.2.1",
     "body-parser": "1.17.2",
@@ -59,7 +61,6 @@
     "nodemailer": "4.0.1",
     "nodemailer-mock-transport": "1.3.0",
     "object-assign": "4.1.1",
-    "octokat": "0.10.0",
     "passport": "0.3.2",
     "passport-github2": "0.1.10",
     "password-generator": "2.1.0",

--- a/pr-check.js
+++ b/pr-check.js
@@ -63,11 +63,12 @@ async function updateStoredPR(pr) {
 }
 
 async function setGhStatus(gh, status) {
-  try {
-    await doAsync(gh).status(status);
-  } catch(err) {
-    log.error(err);
-  }
+  return new Promise((res, rej) => {
+    gh.status(status, (err) => {
+      if (err) log.error(err);
+      res();
+    })
+  });
 }
 
 async function checkPrScope(gh, pr) {

--- a/pr-check.js
+++ b/pr-check.js
@@ -75,7 +75,7 @@ async function checkPrScope(gh, pr) {
   const ignorePath = ".github/";
   let files;
   try {
-    ({items: files} = await gh.getPrFiles(pr.owner, pr.shortName, pr.num));
+    files = await gh.getPrFiles(pr.owner, pr.shortName, pr.num);
   } catch(err) {
     log.error(err);
     // if unsure, assumes it is IPR-relevant


### PR DESCRIPTION
There have been  many reports in the past months of the results of the IPR checker not showing up in the pull request check results (among other things because some repos have started mandating it).

We had identified that github was responding with 404 on the statuses end point in these cases, so I thought this was a bug on the github side, but after interactions with the github support, I came to realize that the bug on the github side is only that github replies with 404 instead of 403.

With further investigation, it appears that in some cases, we were doing POST on the statuses endpoint with an access token that didn't have the rights to POST there. Looking even further, I realized that each time someone imports a repo, their access token for the organization replaces the existing registered token.

This means that a user that can import a repo (which just needs admin rights on the repo) will overwrite the token, whether they have admin rights on the hosting org or not; when that happens, the IPR checker won't be able to push status reports the repo of that org.

This pull request fixes this by only updating the token when the user is an owner of the organization.

We will still need to update all the org tokens (by reimporting an existing repo) once this fix deployed.

We should also have a regular check that the user who produced the token has still the right privileges; the new code records this provenance to make that easier.