### PR TITLE
Fix bug in submitting GH comment

### DIFF
--- a/gh.js
+++ b/gh.js
@@ -81,7 +81,7 @@ GH.prototype = {
         }, cb);
     }
 ,   commentOnPR: function({owner, shortName, num, comment}, cb) {
-        this.octo.request("POST /repos/:owner/:shortName/issues/:num/comments", { owner, shortName, num, data: comment}).then(({data: comment}) => cb(null, comment), cb);
+        this.octo.request("POST /repos/:owner/:shortName/issues/:num/comments", { owner, shortName, num, data: {body: comment}}).then(({data: comment}) => cb(null, comment), cb);
     }
 ,   createRepo: function (data, config, cb) {
         this.createOrImportRepo(data, makeNewRepo, newFile, config, cb);


### PR DESCRIPTION
The current code generates the following error
{
  "name": "HttpError",
  "status": 400,
  "headers": {
    "access-control-allow-origin": "*",
    "access-control-expose-headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
    "connection": "close",
    "content-length": "123",
    "content-security-policy": "default-src 'none'",
    "content-type": "application/json; charset=utf-8",
    "date": "Wed, 29 Jul 2020 06:55:17 GMT",
    "referrer-policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
    "server": "GitHub.com",
    "status": "400 Bad Request",
    "strict-transport-security": "max-age=31536000; includeSubdomains; preload",
    "vary": "Accept-Encoding, Accept, X-Requested-With",
    "x-accepted-oauth-scopes": "",
    "x-content-type-options": "nosniff",
    "x-frame-options": "deny",
    "x-github-media-type": "github.v3; format=json",
    "x-github-request-id": "ABA6:0AE6:131B80:2FE061:5F211D55",
    "x-oauth-client-id": "80bcfc79a48923a2b006",
    "x-oauth-scopes": "public_repo, read:org, user:email, write:repo_hook",
    "x-ratelimit-limit": "15000",
    "x-ratelimit-remaining": "14992",
    "x-ratelimit-reset": "1596008825",
    "x-xss-protection": "1; mode=block"
  },
  "request": {
    "method": "POST",
    "url": "https://api.github.com/repos/w3c/webrtc-pc/issues/2560/comments",
    "headers": {
      "accept": "application/vnd.github.v3+json",
      "user-agent": "octokit-core.js/3.1.0 Node.js/12.18.3 (Linux 4.19; x64)",
      "authorization": "token [REDACTED]",
      "content-type": "application/json; charset=utf-8"
    },
    "body": "Marked as non substantive for IPR from ash-nazg.",
    "request": {}
  },
  "documentation_url": "https://developer.github.com/v3/issues/comments/#create-a-comment"
}