### PR TITLE
Add supports for webhook endpoint coming from W3C API on github account connection

### DIFF
--- a/pr-check.js
+++ b/pr-check.js
@@ -188,9 +188,9 @@ function prChecker(config, argLog, argStore, GH, mailer) {
                 try {
                   nplc = await new Promise((res, rej) => w3c.nplc({repoId: pr.repoId, pr: pr.num}).fetch((err, n) => { if (err) return rej(err); return res(n);}));
                 } catch (err) {
-                  // Non-participant licensing contribution doesn't exist yet
-                  pr.contribStatus[username] = "no commitment made";
-                  return "no commitment made";
+                  // Non-participant licensing contribution doesn't exist
+                  pr.contribStatus[username] = "not in group";
+                  return "not in group";
                 }
                 const u = nplc.commitments.find(c => c.user["connected-accounts"].find(ca => ca.nickname === username));
                 const contribStatus = (u.commitment_date === undefined) ? "commitment pending" : "ok";

--- a/pr-check.js
+++ b/pr-check.js
@@ -198,7 +198,7 @@ function prChecker(config, argLog, argStore, GH, mailer) {
                 return contribStatus;
               } else {
                 pr.contribStatus[username] = "no commitment made - missing repository ID";
-                return "no commiment made - missing repository ID";
+                return "no commitment made - missing repository ID";
               }
             } else {
               pr.contribStatus[username] = "not in group";

--- a/pr-check.js
+++ b/pr-check.js
@@ -197,7 +197,7 @@ function prChecker(config, argLog, argStore, GH, mailer) {
                 pr.contribStatus[username] = contribStatus;
                 return contribStatus;
               } else {
-                pr.contribStatus[username] = "no commiment made - missing repository ID";
+                pr.contribStatus[username] = "no commitment made - missing repository ID";
                 return "no commiment made - missing repository ID";
               }
             } else {

--- a/store.js
+++ b/store.js
@@ -157,6 +157,14 @@ Store.prototype = {
                                     });
                                 }.toString()
                     }
+                ,   by_unaffiliated_contributor: {
+                        map:    function (doc) {
+                                    if (!doc.type || doc.type !== "pr" || !doc.unaffiliatedUsers) return;
+                                    doc.unaffiliatedUsers.forEach(function (u) {
+                                        emit(u, doc);
+                                    });
+                                }.toString()
+                    }
                 ,   by_affiliation: {
                         map:    function (doc) {
                                     if (!doc.type || doc.type !== "pr" || !doc.affiliations) return;
@@ -467,6 +475,14 @@ Store.prototype = {
         this.db.view("prs/by_date", { endkey: couchNow(), startkey: lastWeek }, function (err, docs) {
             if (err) return cb(err);
             log.info("Returning PRs from the past week: " + (docs.length ? "FOUND" : "NOT FOUND"));
+            cb(null, docs.toArray());
+        });
+    }
+,   getUnaffiliatedUserPRs: function (username, cb) {
+        log.info("Looking for PRs with unaffiliated contributor " + username);
+        this.db.view("prs/by_unaffiliated_contributor", { key: username }, function (err, docs) {
+            if (err) return cb(err);
+            log.info("Returning PRs from unaffiliated contributor " + username + ": " + (docs.length ? docs.length + " FOUND" : "NOT FOUND"));
             cb(null, docs.toArray());
         });
     }


### PR DESCRIPTION
Allows to automatically revalidate any pending PR from the said github user
Part of #26