### PR TITLE
Support group participation join webhook

### DIFF
--- a/server.js
+++ b/server.js
@@ -294,7 +294,8 @@ router.post("/api/revalidate", bp.json(), async (req, res) => {
       return res(prs);
     }));
   } else if (req.body.event === "group.participant_joined" && req.body.group && req.body.group.id) {  // new group participant
-    if (!req.body.user || !req.body.user["connected-accounts"] || !req.body.user["connected-accounts"][0] || !req.body.user["connected-accounts"][0]["nickname"]) {
+    let githubAccount = req.body.user  && req.body.user["connected-accounts"] ? req.body.user["connected-accounts"].find(a => a.service === "github") : undefined;
+    if (!githubAccount || !githubAccount.nickname) {
       return res.json({msg: "Ignoring participations when there's no connected account"});
     }
 

--- a/server.js
+++ b/server.js
@@ -297,9 +297,10 @@ router.post("/api/revalidate", bp.json(), async (req, res) => {
     if (!req.body.user || !req.body.user["connected-accounts"] || !req.body.user["connected-accounts"][0] || !req.body.user["connected-accounts"][0]["nickname"]) {
       return res.json({msg: "Ignoring participations when there's no connected account"});
     }
-    getPRs = new Promise((res, rej) => store.getContributorPRs(req.body.user["connected-accounts"][0]["nickname"], (err, prs) => {
+
+    getPRs = new Promise((res, rej) => store.getOutsideUserPRs(req.body.user["connected-accounts"][0]["nickname"], (err, prs) => {
       if (err) return rej(err);
-      const groupPRs = prs.filter(pr => pr.groups.includes(req.body.group.id));
+      const groupPRs = prs.filter(pr => pr.groups ? pr.groups.includes(req.body.group.id.toString()) : false);
       log.info("Found contributors for group PRs " + JSON.stringify(groupPRs, null, 2));
       return res(groupPRs);
     }));

--- a/server.js
+++ b/server.js
@@ -284,6 +284,7 @@ router.post("/api/revalidate", bp.json(), async (req, res) => {
     return error(res, "Invalid request sent to revalidate endpoint");
   }
 
+  let getPRs;
   if (req.body.event === "connected_account.created" && req.body.account && req.body.account.nickname) {  // new connected account
     if (!req.body.account.service === "github") {
       return res.json({msg: "Ignoring updates to accounts other than github"});

--- a/store.js
+++ b/store.js
@@ -165,6 +165,14 @@ Store.prototype = {
                                     });
                                 }.toString()
                     }
+                ,   by_contributor: {
+                        map:    function (doc) {
+                                    if (!doc.type || doc.type !== "pr" || !doc.contributors) return;
+                                    doc.contributors.forEach(function (u) {
+                                        emit(u, doc);
+                                    });
+                                }.toString()
+                    }
                 ,   by_affiliation: {
                         map:    function (doc) {
                                     if (!doc.type || doc.type !== "pr" || !doc.affiliations) return;
@@ -483,6 +491,14 @@ Store.prototype = {
         this.db.view("prs/by_unaffiliated_contributor", { key: username }, function (err, docs) {
             if (err) return cb(err);
             log.info("Returning PRs from unaffiliated contributor " + username + ": " + (docs.length ? docs.length + " FOUND" : "NOT FOUND"));
+            cb(null, docs.toArray());
+        });
+    }
+,   getContributorPRs: function (username, cb) {
+        log.info("Looking for PRs from " + username);
+        this.db.view("prs/by_contributor", { key: username }, function (err, docs) {
+            if (err) return cb(err);
+            log.info("Returning PRs from " + username + ": " + (docs.length ? docs.length + " FOUND" : "NOT FOUND"));
             cb(null, docs.toArray());
         });
     }

--- a/store.js
+++ b/store.js
@@ -165,10 +165,10 @@ Store.prototype = {
                                     });
                                 }.toString()
                     }
-                ,   by_contributor: {
+                ,   by_outside_contributor: {
                         map:    function (doc) {
-                                    if (!doc.type || doc.type !== "pr" || !doc.contributors) return;
-                                    doc.contributors.forEach(function (u) {
+                                    if (!doc.type || doc.type !== "pr" || !doc.outsideUsers) return;
+                                    doc.outsideUsers.forEach(function (u) {
                                         emit(u, doc);
                                     });
                                 }.toString()
@@ -494,11 +494,11 @@ Store.prototype = {
             cb(null, docs.toArray());
         });
     }
-,   getContributorPRs: function (username, cb) {
-        log.info("Looking for PRs from " + username);
-        this.db.view("prs/by_contributor", { key: username }, function (err, docs) {
+,   getOutsideUserPRs: function (username, cb) {
+        log.info("Looking for PRs with outside contributor " + username);
+        this.db.view("prs/by_outside_contributor", { key: username }, function (err, docs) {
             if (err) return cb(err);
-            log.info("Returning PRs from " + username + ": " + (docs.length ? docs.length + " FOUND" : "NOT FOUND"));
+            log.info("Returning PRs from outside contributor " + username + ": " + (docs.length ? docs.length + " FOUND" : "NOT FOUND"));
             cb(null, docs.toArray());
         });
     }


### PR DESCRIPTION
This is a follow-up of #183 to revalidate PRs when there's a new group participation.
A new view needs to be created in the store by running `node store.js`