### PR TITLE
Handle W3C API new group URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "express": "4.15.3",
     "express-session": "1.15.3",
     "express-winston": "2.4.0",
-    "node-w3capi": "1.8.0",
+    "node-w3capi": "1.10.0",
     "nodemailer": "4.0.1",
     "nodemailer-mock-transport": "1.3.0",
     "object-assign": "4.1.1",

--- a/pr-check.js
+++ b/pr-check.js
@@ -173,17 +173,18 @@ function prChecker(config, argLog, argStore, GH, mailer) {
           }
 
           let groups = [];
+          const types = {
+            'working group': 'wg',
+            'interest group': 'ig',
+            'community group': 'cg',
+            'business group': 'bg'
+          };
+
           for (g of repoGroups) {
             // get group type and shortname
-            await new Promise((res, rej) => w3c.group(g).fetch((err, group) => {
+            await new Promise((res, rej) => w3c.group(parseInt(g, 10)).fetch((err, group) => {
               if (err) return rej(err);
-              const types = {
-                'working group': 'wg',
-                'interest group': 'ig',
-                'community group': 'cg',
-                'business group': 'bg'
-              };
-              groups.push({id: group.id, type: types[group.type], shortname: group.shortname});
+              groups.push({id: g, type: types[group.type], shortname: group.shortname});
               res();
             }));
           }

--- a/pr-check.js
+++ b/pr-check.js
@@ -171,7 +171,24 @@ function prChecker(config, argLog, argStore, GH, mailer) {
             pr.contribStatus[username] = "undetermined affiliation";
             return "undetermined affiliation";
           }
-          let result = await w3ciprcheck(w3c, user.w3capi, user.displayName, repoGroups, store);
+
+          let groups = [];
+          for (g of repoGroups) {
+            // get group type and shortname
+            await new Promise((res, rej) => w3c.group(g).fetch((err, group) => {
+              if (err) return rej(err);
+              const types = {
+                'working group': 'wg',
+                'interest group': 'ig',
+                'community group': 'cg',
+                'business group': 'bg'
+              };
+              groups.push({id: group.id, type: types[group.type], shortname: group.shortname});
+              res();
+            }));
+          }
+
+          let result = await w3ciprcheck(w3c, user.w3capi, user.displayName, groups, store);
           let ok = result.ok;
           if (ok) {
             pr.affiliations[result.affiliation.id] = result.affiliation.name;

--- a/pr-check.js
+++ b/pr-check.js
@@ -2,7 +2,13 @@ const async = require("async")
 ,   notification = require('./notification')
 ,   w3ciprcheck = require('./w3c-ipr')
 ,   doAsync = require('doasync') // rather than utils.promisy to get "free" support for object methods
-,   w3c = require("node-w3capi");
+,   w3c = require("node-w3capi")
+,   types = {
+      'working group': 'wg',
+      'interest group': 'ig',
+      'community group': 'cg',
+      'business group': 'bg'
+    };
 
 let store, log;
 
@@ -173,12 +179,6 @@ function prChecker(config, argLog, argStore, GH, mailer) {
           }
 
           let groups = [];
-          const types = {
-            'working group': 'wg',
-            'interest group': 'ig',
-            'community group': 'cg',
-            'business group': 'bg'
-          };
 
           for (g of repoGroups) {
             // get group type and shortname

--- a/w3c-ipr.js
+++ b/w3c-ipr.js
@@ -1,10 +1,10 @@
 const fromUrlToId = url => url.replace(/.*\//, "");
 
-module.exports = async function iprcheck(w3c, w3cprofileid, name, w3cgroupids, store, cb) {
+module.exports = async function iprcheck(w3c, w3cprofileid, name, w3cgroups, store, cb) {
   return Promise.all(
-    w3cgroupids.map(
-      g => new Promise((res, rej) => {
-        store.getGroup(g, function(err, group) {
+    w3cgroups.map(
+      ({id, type, shortname}) => new Promise((res, rej) => {
+        store.getGroup(id, function(err, group) {
           if (err) return rej(err);
           w3c.user(w3cprofileid)
             .participations()
@@ -15,7 +15,7 @@ module.exports = async function iprcheck(w3c, w3cprofileid, name, w3cgroupids, s
                        var p = participations[i];
                        var org = p._links.organization;
                        var affiliation = p.individual ? {id: w3cprofileid, name: name} : {id: fromUrlToId(org.href), name: org.title};
-                       if (p._links.group.href === "https://api.w3.org/groups/" + g) {
+                       if (p._links.group.href === `https://api.w3.org/groups/${type}/${shortname}`) {
                          return res({ok: true, affiliation: affiliation});
                        }
                      }
@@ -27,7 +27,7 @@ module.exports = async function iprcheck(w3c, w3cprofileid, name, w3cgroupids, s
                      }
                      // For WGs, we check if the user is affiliated
                      // with an organization that is participating
-                     w3c.group(g)
+                     w3c.group({type, shortname})
                        .participations()
                        .fetch({embed: true}, function(err, participations) {
                          if (err) return rej(err);


### PR DESCRIPTION
The W3C API now lists the group links based on their type/shortname, e.g. https://api.w3.org/groups/wg/payments.
While the W3C API still support the URLs with the group ID (https://api.w3.org/groups/83744), ash-nazg needs to be updated to check the new URLs.

The W3C API has been temporarily reverted so it doesn't break ash-nazg. Once that PR is merged, the API will have to be updated again.