### PR TITLE
Upgrade to node-w3capi 1.10.1 to support different type of group parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "express": "4.15.3",
     "express-session": "1.15.3",
     "express-winston": "2.4.0",
-    "node-w3capi": "1.10.0",
+    "node-w3capi": "1.10.1",
     "nodemailer": "6.4.16",
     "nodemailer-mock-transport": "1.3.0",
     "object-assign": "4.1.1",

--- a/pr-check.js
+++ b/pr-check.js
@@ -182,7 +182,7 @@ function prChecker(config, argLog, argStore, GH, mailer) {
 
           for (g of repoGroups) {
             // get group type and shortname
-            await new Promise((res, rej) => w3c.group(parseInt(g, 10)).fetch((err, group) => {
+            await new Promise((res, rej) => w3c.group(g).fetch((err, group) => {
               if (err) return rej(err);
               groups.push({id: g, type: types[group.type], shortname: group.shortname});
               res();


### PR DESCRIPTION
As explained in https://github.com/w3c/node-w3capi/pull/71, this is breaking some endpoints of the repo manager. I'll merge now to avoid more disruption.