### PR TITLE
Operation errors patch

### DIFF
--- a/gh.js
+++ b/gh.js
@@ -280,12 +280,12 @@ GH.prototype = {
     }
 };
 
-GH.signPayload = function (algo, secret, buffer) {
-    return algo + "=" + crypto.createHmac(algo, secret).update(buffer).digest("hex");
-};
-
 GH.checkPayloadSignature = function (algo, secret, buffer, remotesig) {
-    return crypto.timingSafeEqual(Buffer.from(GH.signPayload(algo, secret, buffer)), Buffer.from(remotesig));
-};
+    const sig = Buffer.from(remotesig, 'utf-8');
+    const hmac = crypto.createHmac(algo, secret);
+    const digest = Buffer.from(algo + '=' + hmac.update(buffer).digest('hex'), 'utf8')
+    
+    return (sig.length === digest.length && crypto.timingSafeEqual(digest, sig));
+}
 
 module.exports = GH;

--- a/gh.js
+++ b/gh.js
@@ -280,10 +280,13 @@ GH.prototype = {
     }
 };
 
+GH.signPayload = function (algo, secret, buffer) {
+    return algo + "=" + crypto.createHmac(algo, secret).update(buffer).digest("hex");
+};
+
 GH.checkPayloadSignature = function (algo, secret, buffer, remotesig) {
     const sig = Buffer.from(remotesig, 'utf-8');
-    const hmac = crypto.createHmac(algo, secret);
-    const digest = Buffer.from(algo + '=' + hmac.update(buffer).digest('hex'), 'utf8')
+    const digest = Buffer.from(GH.signPayload(algo, secret, buffer), 'utf8')
     
     return (sig.length === digest.length && crypto.timingSafeEqual(digest, sig));
 }

--- a/pr-check.js
+++ b/pr-check.js
@@ -182,11 +182,15 @@ function prChecker(config, argLog, argStore, GH, mailer) {
 
           for (g of repoGroups) {
             // get group type and shortname
-            await new Promise((res, rej) => w3c.group(g).fetch((err, group) => {
-              if (err) return rej(err);
-              groups.push({id: g, type: types[group.type], shortname: group.shortname});
-              res();
-            }));
+            try {
+              await new Promise((res, rej) => w3c.group(g).fetch((err, group) => {
+                if (err) return rej(err);
+                groups.push({id: g, type: types[group.type], shortname: group.shortname});
+                res();
+              }));
+            } catch (err) {
+              return cb(err);
+            }
           }
 
           let result = await w3ciprcheck(w3c, user.w3capi, user.displayName, groups, store);

--- a/server.js
+++ b/server.js
@@ -450,7 +450,7 @@ function addGHHook(app, path) {
                 }
 
                 // we have the secret, crypto check becomes possible
-                if (!GH.checkPayloadSignature("sha256", data.secret, buffer, req.headers["x-hub-signature"])) return error(res, "GitHub signature does not match known secret for " + repo + ".");
+                if (!GH.checkPayloadSignature("sha256", data.secret, buffer, req.headers["x-hub-signature-256"])) return error(res, "GitHub signature does not match known secret for " + repo + ".");
 
                 // for status we need: owner, repoShort, and sha
                 var repoShort = event.repository.name

--- a/server.js
+++ b/server.js
@@ -1,5 +1,8 @@
 
 // this is where the express app goes
+
+const doAsync = require("doasync");
+
 // 3043
 var express = require("express")
 ,   exwin = require("express-winston")
@@ -415,11 +418,31 @@ function addGHHook(app, path) {
 
             var owner = event.repository.owner.login
             ,   repo = event.repository.full_name
+            ,   repoShortname = event.repository.name
             ,   repoId = event.repository.id
             ;
-            store.getSecret(repo, function (err, data) {
-                // if there's an error, we can't set an error on the status because we have no secret, so bail
-                if (err || !data) return error(res, "Secret for " + repo + " not found: " + (err || "simply not there."));
+            store.getSecret(repo, async function (err, data) {
+                if (err || !data) {
+                    const { token } = await doAsync(store).getToken(owner);
+                    const gh = new GH({ accessToken: token });
+                    const statusData = {
+                        owner,
+                        shortName: repoShortname,
+                        sha: event.pull_request.head.sha,
+                        payload: {
+                            state: "failure",
+                            target_url: config.url + "pr/id/" + owner + "/" + repo.split('/')[1] + "/" + event.number,
+                            description: `The repository manager doesn't know the following repository: ${repo}`,
+                            context: "ipr"
+                        }
+                    };
+                    gh.status(statusData, err => {
+                        if (err) {
+                            log.error(err);
+                        }
+                    });
+                    return error(res, "Secret for " + repo + " not found: " + (err || "simply not there."));
+                }
 
                 // we have the secret, crypto check becomes possible
                 if (!GH.checkPayloadSignature("sha1", data.secret, buffer, req.headers["x-hub-signature"])) return error(res, "GitHub signature does not match known secret for " + repo + ".");

--- a/test/server-spec.js
+++ b/test/server-spec.js
@@ -640,7 +640,7 @@ describe('Server manages requests from advanced privileged users in a set up rep
         req.post('/' + config.hookPath)
             .send(testPR2)
             .set('X-Github-Event', 'pull_request')
-            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testPR2))))
+            .set('X-Hub-Signature-256', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testPR2))))
             .expect(500, done);
     });
 
@@ -668,7 +668,7 @@ describe('Server manages requests from advanced privileged users in a set up rep
         req.post('/' + config.hookPath)
             .send(testPR)
             .set('X-Github-Event', 'pull_request')
-            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testPR))))
+            .set('X-Hub-Signature-256', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testPR))))
             .expect(200, function(err, res) {
                 if (err) return done(err);
                 expect(transport.sentMail.length).to.be.equal(2);
@@ -698,7 +698,7 @@ describe('Server manages requests from advanced privileged users in a set up rep
         req.post('/' + config.hookPath)
             .send(testIPRFreePR)
             .set('X-Github-Event', 'pull_request')
-            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testIPRFreePR))))
+            .set('X-Hub-Signature-256', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testIPRFreePR))))
             .expect(200, done);
     });
 
@@ -884,7 +884,7 @@ describe('Server manages requests from advanced privileged users in a set up rep
         req.post('/' + config.hookPath)
             .send(forcedPR)
             .set('X-Github-Event', 'pull_request')
-            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(forcedPR))))
+            .set('X-Hub-Signature-256', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(forcedPR))))
             .expect(200, done);
     });
 
@@ -908,7 +908,7 @@ describe('Server manages requests from advanced privileged users in a set up rep
         req.post('/' + config.hookPath)
             .send(testCGPR)
             .set('X-Github-Event', 'pull_request')
-            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testCGPR))))
+            .set('X-Hub-Signature-256', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testCGPR))))
             .expect(200, function(err) {
                 if (err) return done(err);
                 expect(transport.sentMail.length).to.be.equal(1);
@@ -934,7 +934,7 @@ describe('Server manages requests from advanced privileged users in a set up rep
         req.post('/' + config.hookPath)
             .send(testWGPR)
             .set('X-Github-Event', 'pull_request')
-            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testWGPR))))
+            .set('X-Hub-Signature-256', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testWGPR))))
             .expect(200, done);
 
     });

--- a/test/server-spec.js
+++ b/test/server-spec.js
@@ -121,8 +121,31 @@ var testCGRepo = new RepoMock(789, "cgrepo","acme", ["README.md", "index.html"],
 var testPR = {
     repository: testExistingRepo.toGH(),
     number: 5,
-  action: "opened",
-  files: [{filename: "foo.bar"}],
+    action: "opened",
+    files: [{filename: "foo.bar"}],
+    pull_request: {
+        head: {
+            sha: "fedcbafedcbafedcbafedcbafedcbafedcbafedc"
+        },
+        user: {
+            login: testUser2.username
+        },
+        body: "+@" + testUser3.username
+    }
+};
+
+var testPR2 = {
+    repository: {
+        id: 111,
+        name: 'newrepo2',
+        full_name: 'acme/newrepo2',
+        owner: {
+            login: 'acme'
+        }
+    },
+    number: 5,
+    action: "opened",
+    files: [{filename: "foo.bar"}],
     pull_request: {
         head: {
             sha: "fedcbafedcbafedcbafedcbafedcbafedcbafedc"
@@ -601,7 +624,6 @@ describe('Server manages requests from advanced privileged users in a set up rep
         });
     });
 
-
     it('allows admins to add a new user', function testAddUser(done) {
         nock('https://api.github.com')
             .get('/users/' + testUser2.username)
@@ -610,6 +632,16 @@ describe('Server manages requests from advanced privileged users in a set up rep
         authAgent
             .post('/api/user/' + testUser2.username + '/add')
             .expect(200, done);
+    });
+
+    it('reacts to pull requests notifications from unknown repository', function testUnknownRepo(done) {
+        mockPRStatus(testPR2, 'failure', /The repository manager doesn't know the following repository:.*/);
+
+        req.post('/' + config.hookPath)
+            .send(testPR2)
+            .set('X-Github-Event', 'pull_request')
+            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testPR2))))
+            .expect(500, done);
     });
 
     it('reacts to pull requests notifications from GH users without a known W3C account', function testPullRequestNotif(done) {
@@ -636,7 +668,7 @@ describe('Server manages requests from advanced privileged users in a set up rep
         req.post('/' + config.hookPath)
             .send(testPR)
             .set('X-Github-Event', 'pull_request')
-            .set('X-Hub-Signature', GH.signPayload("sha1", passwordGenerator(20), new Buffer(JSON.stringify(testPR))))
+            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testPR))))
             .expect(200, function(err, res) {
                 if (err) return done(err);
                 expect(transport.sentMail.length).to.be.equal(2);
@@ -666,7 +698,7 @@ describe('Server manages requests from advanced privileged users in a set up rep
         req.post('/' + config.hookPath)
             .send(testIPRFreePR)
             .set('X-Github-Event', 'pull_request')
-            .set('X-Hub-Signature', GH.signPayload("sha1", passwordGenerator(20), new Buffer(JSON.stringify(testIPRFreePR))))
+            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testIPRFreePR))))
             .expect(200, done);
     });
 
@@ -852,7 +884,7 @@ describe('Server manages requests from advanced privileged users in a set up rep
         req.post('/' + config.hookPath)
             .send(forcedPR)
             .set('X-Github-Event', 'pull_request')
-            .set('X-Hub-Signature', GH.signPayload("sha1", passwordGenerator(20), new Buffer(JSON.stringify(forcedPR))))
+            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(forcedPR))))
             .expect(200, done);
     });
 
@@ -876,7 +908,7 @@ describe('Server manages requests from advanced privileged users in a set up rep
         req.post('/' + config.hookPath)
             .send(testCGPR)
             .set('X-Github-Event', 'pull_request')
-            .set('X-Hub-Signature', GH.signPayload("sha1", passwordGenerator(20), new Buffer(JSON.stringify(testCGPR))))
+            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testCGPR))))
             .expect(200, function(err) {
                 if (err) return done(err);
                 expect(transport.sentMail.length).to.be.equal(1);
@@ -902,7 +934,7 @@ describe('Server manages requests from advanced privileged users in a set up rep
         req.post('/' + config.hookPath)
             .send(testWGPR)
             .set('X-Github-Event', 'pull_request')
-            .set('X-Hub-Signature', GH.signPayload("sha1", passwordGenerator(20), new Buffer(JSON.stringify(testWGPR))))
+            .set('X-Hub-Signature', GH.signPayload("sha256", passwordGenerator(20), new Buffer(JSON.stringify(testWGPR))))
             .expect(200, done);
 
     });


### PR DESCRIPTION
That PR:
* updates the status of the PR to `failure` if the targeted repository is not known to the repository manager
* updates the [signature verification using sha256](https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github)
* handles a promise rejection

Fix #210 

Regarding handling repository renaming, I made some [suggestions](https://github.com/w3c/ash-nazg/issues/64#issuecomment-882613167) we can discuss.