### PR TITLE
fix webhook secret during the update

### DIFF
--- a/webhook-update.js
+++ b/webhook-update.js
@@ -42,7 +42,7 @@ if (require.main === module) {
                                 config: {
                                     url:          config.hookURL || (config.url + "api/hook"),
                                     content_type: "json",
-                                    secret:       secret
+                                    secret:       secret.secret
                                 }
                                 ,   events: ["pull_request", "issue_comment", "repository"]
                             }


### PR DESCRIPTION
The PRs submitted after the webhook updates fail because of the wrong secret. That's because the secret passed was wrong. That PR fixes that.