### PR TITLE
oauth login: fix response

### DIFF
--- a/test/server-spec.js
+++ b/test/server-spec.js
@@ -252,7 +252,7 @@ function login(agent, admin, cb) {
         client_secret: config.ghClientSecret,
         code: 'abcd'
     })
-    .reply(302, {location: config.url + '?access_token=bcdef&scope='+ encodeURIComponent(ghScope) + '&token_type=bearer'});
+    .reply(302, {location: config.url, access_token: "bcdef", scope: encodeURIComponent(ghScope), token_type: "bearer"});
 
 
     nock('https://api.github.com')


### PR DESCRIPTION
The last version of `passport-oauth2` (1.6.1, see [changelog](https://github.com/jaredhanson/passport-oauth2/compare/v1.6.0...v1.6.1)) is breaking the test suite as it'll return an error if an `access_token` cannot be found.
That PR updates the body according to the [doc](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github) so the `access_token` can be correctly parsed.