### PR TITLE
Force disconnection for users with old format tokens

### DIFF
--- a/server.js
+++ b/server.js
@@ -163,7 +163,8 @@ router.get("/api/logout", function (req, res) {
 
 // check if the user is logged in
 router.get("/api/logged-in", function (req, res) {
-    if (req.user && req.user.accessToken && !req.user.accessToken.startsWith("gho")) {
+    // Format of github OAuth access tokens per https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/
+    if (req.user && req.user.accessToken && !req.user.accessToken.startsWith("gho_")) {
         log.info(`Force disconnect of ${req.user.username}`);
         req.logout();
     }

--- a/server.js
+++ b/server.js
@@ -163,6 +163,10 @@ router.get("/api/logout", function (req, res) {
 
 // check if the user is logged in
 router.get("/api/logged-in", function (req, res) {
+    if (req.user && req.user.accessToken && !req.user.accessToken.startsWith("gho")) {
+        log.info(`Force disconnect of ${req.user.username}`);
+        req.logout();
+    }
     res.json({ ok: req.isAuthenticated(), login: req.user ? req.user.username : null, admin: req.user ? req.user.admin : false });
 });
 


### PR DESCRIPTION
We receive regular notices that some users still rely on old format tokens. That PR forces these users to re-login so a new token will be generated.