### PR TITLE
revalidate endpoint: return a HTTP 200 if the event is not supported

### DIFF
--- a/server.js
+++ b/server.js
@@ -336,7 +336,7 @@ router.post("/api/revalidate", bp.json(), async (req, res) => {
       return res(groupPRs);
     }));
   } else {
-    return error(res, "Invalid request sent to revalidate endpoint");
+    return res.json({msg: "Skipped revalidation for this event."});
   }
 
   try {


### PR DESCRIPTION
The revalidate endpoint returns an error if the webhook event isn't supported causing them to resurface on the webhook history page.
That PR replaces the error with a http 200