### PR TITLE
update link to non-participant contribution form

### DIFF
--- a/application/pr/viewer.jsx
+++ b/application/pr/viewer.jsx
@@ -131,7 +131,7 @@ export default class PRViewer extends React.Component {
                 let nplc;
                 if ((this.props.isAdmin || st.isTeamcontact) && st.pr.repoId && !Object.keys(cs).some(u => cs[u] === "undetermined affiliation")) {
                     let st = this.state
-                    ,   nplcUrl = new URL(['/2004/01/pp-impl/nplc', st.pr.repoId, st.num, 'edit'].join("/"), 'https://www.w3.org/')
+                    ,   nplcUrl = new URL(['/standards/licensing/contributions', st.pr.repoId, st.num, 'edit/'].join("/"), 'https://www.w3.org/')
                     ,   qs = st.pr.contributors.map(c => 'contributors[]=' + c).concat(st.pr.groups.map(g => 'groups[]=' + g)).join('&')
                     ;
                     nplcUrl.search = qs;


### PR DESCRIPTION
With the redesign, the URL to the form to request the non-participant commitments was updated from `/2004/01/pp-impl/nplc/<repo>/<pr>/edit` to `/standards/licensing/contributions/repo/pr/edit/` (see [example](https://www.w3.org/standards/licensing/contributions/9252268/9285/edit/?contributors[]=darktears&groups[]=32061)).
That PR fixes the link that appears in the repo-manager.