### PR TITLE
Update CG-license.md

### DIFF
--- a/templates/CG-license.md
+++ b/templates/CG-license.md
@@ -1,9 +1,9 @@
-All Reports in this Repository are licensed by Contributors
-under the
-[W3C Software and Document License](https://www.w3.org/copyright/software-license/).
-
 Contributions to Specifications are made under the
 [W3C CLA](https://www.w3.org/community/about/process/cla/).
+
+Contributions to other types of Reports in this Repository are licensed by Contributors
+under the
+[W3C Software and Document License](https://www.w3.org/copyright/software-license/).
 
 Contributions to Test Suites are made under the
 [W3C 3-clause BSD License](https://www.w3.org/copyright/3-clause-bsd-license-2008/)


### PR DESCRIPTION
Clarify that specs are under CLA; other reports are not. This wording makes that clearer.