### PR TITLE
Repository transfer: fix previous owner 

### DIFF
--- a/server.js
+++ b/server.js
@@ -459,7 +459,8 @@ function addGHHook(app, path) {
                 if (event.action === "renamed") {
                     previousRepo = `${owner}/${event.changes.repository.name.from}`;
                 } else if (event.action === "transferred") {
-                    previousRepo = `${event.changes.owner.from.user.login}/${repoShortname}`;
+                    const previousOwner = event.changes.owner.from.organization ?? event.changes.owner.from.user;
+                    previousRepo = `${previousOwner.login}/${repoShortname}`;
                 } else {
                     return ok(res);
                 }


### PR DESCRIPTION
When a repository is being transferred, the [webhook payload differentiates the type of the previous owner](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=transferred#repository) (organization or user).

That PR fixes the way we retrieve the name of the owner.
